### PR TITLE
Fix SVGO for brunch >= 2.10.3

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,5 +35,6 @@ class SVGOBrunch {
 SVGOBrunch.prototype.brunchPlugin = true;
 SVGOBrunch.prototype.staticTargetExtension = 'svg';
 SVGOBrunch.prototype.staticExtension = 'svg';
+SVGOBrunch.prototype.type = 'template'; // See https://github.com/brunch/brunch/issues/1688#issuecomment-289083583 , waiting for new `optimize` API to be done
 
 module.exports = SVGOBrunch;


### PR DESCRIPTION
brunch 2.10.3 introduce a BC break : it does not allow "compileStatic" method to be called on non-template. 

Fixing this while new API is not released.

See https://github.com/brunch/brunch/issues/1688#issuecomment-289083583 for more informations